### PR TITLE
Trait search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-
+.DS_Store
+content/.DS_Store
+content/lang.DS_Store
 config/symbini.php
 config/dbconnection.php

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ content/.DS_Store
 content/lang.DS_Store
 config/symbini.php
 config/dbconnection.php
+cdt_notes.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-.DS_Store
-content/.DS_Store
-content/lang.DS_Store
+
 config/symbini.php
 config/dbconnection.php
-cdt_notes.txt

--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -795,6 +795,14 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 				unset($this->searchTermArr["includecult"]);
 			}
 		}
+		if(array_key_exists("isreproductive",$_REQUEST)){
+			if($_REQUEST["isreproductive"]){
+				$this->searchTermArr["isreproductive"] = true;
+			}
+			else{
+				unset($this->searchTermArr["isreproductive"]);
+			}
+		}
 		$llPattern = '-?\d+\.{0,1}\d*';
 		if(array_key_exists("upperlat",$_REQUEST)){
 			$upperLat = ''; $bottomlat = ''; $leftLong = ''; $rightlong = '';

--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -806,7 +806,7 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 				unset($this->searchTermArr["includecult"]);
 			}
 		}
-		// loop over all "traitid-" fields
+		// Traits search: loop over all "traitid-" fields
 		foreach ($_REQUEST as $reqkey => $reqval){
 			if("traitid-" == substr($reqkey, 0, 8)){
 				if($reqval){

--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -411,6 +411,10 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 				$this->displaySearchArr[] = 'includes cultivated/captive occurrences';
 			}
 		}
+		if(array_key_exists("isreproductive",$this->searchTermArr)){
+			$sqlWhere .= "AND (o.occid IN(SELECT occid FROM tmattributes WHERE stateid = 2)) ";
+			$this->displaySearchArr[] = 'is in reproductive condition';
+		}
 		if($sqlWhere){
 			$this->sqlWhere = 'WHERE '.substr($sqlWhere,4);
 		}

--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -249,6 +249,7 @@ $searchVar = $collManager->getQueryTermStr();
 				<div><button type="button" style="width:100%" onclick="displayTableView(this.form)"><?php echo isset($LANG['BUTTON_NEXT_TABLE'])?$LANG['BUTTON_NEXT_TABLE']:'Table Display'; ?></button></div>
 			</div>
 			<?php
+			if(isset($SEARCH_BY_TRAITS) && $SEARCH_BY_TRAITS = 1) {
 				$traitArr = $attribSearch->getTraitArr();
 				if($traitArr){
 					?>
@@ -278,6 +279,7 @@ $searchVar = $collManager->getQueryTermStr();
 					}
 					echo '<hr />';
 				}
+			}
 			?>
 			<div>
 				<input type="hidden" name="reset" value="1" />

--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -220,10 +220,6 @@ $searchVar = $collManager->getQueryTermStr();
 				<input type="text" id="eventdate2" size="32" name="eventdate2" style="width:100px;" value="" title="<?php echo $LANG['TITLE_TEXT_4']; ?>" />
 			</div>
 			<hr/>
-			<div style="float:right;">
-				<div><button type="submit" style="width:100%"><?php echo isset($LANG['BUTTON_NEXT_LIST'])?$LANG['BUTTON_NEXT_LIST']:'List Display'; ?></button></div>
-				<div><button type="button" style="width:100%" onclick="displayTableView(this.form)"><?php echo isset($LANG['BUTTON_NEXT_TABLE'])?$LANG['BUTTON_NEXT_TABLE']:'Table Display'; ?></button></div>
-			</div>
 			<div>
 				<div style="font-weight:bold; font-size: 18px"><?php echo $LANG['SPECIMEN_HEADER']; ?></div>
 			</div>
@@ -243,6 +239,23 @@ $searchVar = $collManager->getQueryTermStr();
 			</div>
 			<div>
 				<input type='checkbox' name='includecult' value='1' /> <?php echo isset($LANG['INCLUDE_CULTIVATED'])?$LANG['INCLUDE_CULTIVATED']:'Include cultivated/captive occurrences'; ?>
+			</div>
+			<hr/>
+			<div style="float:right;">
+				<div><button type="submit" style="width:100%"><?php echo isset($LANG['BUTTON_NEXT_LIST'])?$LANG['BUTTON_NEXT_LIST']:'List Display'; ?></button></div>
+				<div><button type="button" style="width:100%" onclick="displayTableView(this.form)"><?php echo isset($LANG['BUTTON_NEXT_TABLE'])?$LANG['BUTTON_NEXT_TABLE']:'Table Display'; ?></button></div>
+			</div>
+			<div>
+				<div style="font-weight:bold; font-size: 18px"><?php echo $LANG['TRAIT_HEADER']; ?></div>
+			</div>
+			<div>
+				<input type='checkbox' name='isreproductive' value='1' /> <?php echo isset($LANG['IS_REPRODUCTIVE'])?$LANG['IS_REPRODUCTIVE']:'At least one reproductive structure of any kind is present (flowers, flower buds, fruits)'; ?>
+			</div>
+			<div>
+				<input type='checkbox' name='issterile' value='1' /> <?php echo isset($LANG['IS_STERILE'])?$LANG['IS_STERILE']:'No reproductive structures present (no unopen, open, or senesced flowers or fruits)'; ?>
+			</div>
+			<div>
+				<input type='checkbox' name='isnotscorable' value='1' /> <?php echo isset($LANG['IS_NOTSCORABLE'])?$LANG['IS_NOTSCORABLE']:'Not possible to score reproductive condition using material present'; ?>
 			</div>
 			<div>
 				<input type="hidden" name="reset" value="1" />

--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -2,9 +2,11 @@
 include_once('../config/symbini.php');
 include_once($SERVER_ROOT.'/content/lang/collections/harvestparams.'.$LANG_TAG.'.php');
 include_once($SERVER_ROOT.'/classes/OccurrenceManager.php');
+include_once($SERVER_ROOT.'/classes/OccurrenceAttributes.php');
 header("Content-Type: text/html; charset=".$CHARSET);
 
 $collManager = new OccurrenceManager();
+$attribSearch = new OccurrenceAttributes();
 $searchVar = $collManager->getQueryTermStr();
 ?>
 <html>
@@ -24,6 +26,7 @@ $searchVar = $collManager->getQueryTermStr();
 	<script src="../js/jquery-3.2.1.min.js?ver=3" type="text/javascript"></script>
 	<script src="../js/jquery-ui-1.12.1/jquery-ui.min.js?ver=3" type="text/javascript"></script>
 	<script src="../js/symb/collections.harvestparams.js?ver=180721" type="text/javascript"></script>
+	<script src="../js/symb/collections.traitattr.js?ver=8" type="text/javascript"></script> 
 	<script type="text/javascript">
 		$(document).ready(function() {
 			<?php
@@ -248,15 +251,31 @@ $searchVar = $collManager->getQueryTermStr();
 			<div>
 				<div style="font-weight:bold; font-size: 18px"><?php echo $LANG['TRAIT_HEADER']; ?></div>
 			</div>
-			<div>
-				<input type='checkbox' name='isreproductive' value='1' /> <?php echo isset($LANG['IS_REPRODUCTIVE'])?$LANG['IS_REPRODUCTIVE']:'At least one reproductive structure of any kind is present (flowers, flower buds, fruits)'; ?>
-			</div>
-			<div>
-				<input type='checkbox' name='issterile' value='1' /> <?php echo isset($LANG['IS_STERILE'])?$LANG['IS_STERILE']:'No reproductive structures present (no unopen, open, or senesced flowers or fruits)'; ?>
-			</div>
-			<div>
-				<input type='checkbox' name='isnotscorable' value='1' /> <?php echo isset($LANG['IS_NOTSCORABLE'])?$LANG['IS_NOTSCORABLE']:'Not possible to score reproductive condition of material'; ?>
-			</div>
+			<?php
+				$traitArr = $attribSearch->getTraitArr();
+				if($traitArr){
+					foreach($traitArr as $traitID => $traitData){
+						if(!isset($traitData['dependentTrait'])) {
+						?>
+						<fieldset style="margin-top:20px">
+							<legend><b>Trait: <?php echo $traitData['name']; ?></b></legend>
+							<div style="float:right">
+								<div class="trianglediv" style="margin:4px 3px;float:right;cursor:pointer" onclick="setAttributeTree(this)" title="Toggle attribute tree open/close">
+									<img class="triangleright" src="../images/triangleright.png" style="" />
+									<img class="triangledown" src="../images/triangledown.png" style="display:none" />
+								</div>
+							</div>
+							<div class="traitDiv" style="margin-left:5px;float:left">
+								<?php
+									$attribSearch->echoFormTraits($traitID);
+								?>
+							</div>
+						</fieldset>
+						<?php
+						}
+					}
+				}
+			?>
 			<div>
 				<input type="hidden" name="reset" value="1" />
 				<input type="hidden" name="db" value="<?php echo $collManager->getSearchTerm('db'); ?>" />

--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -26,7 +26,7 @@ $searchVar = $collManager->getQueryTermStr();
 	<script src="../js/jquery-3.2.1.min.js?ver=3" type="text/javascript"></script>
 	<script src="../js/jquery-ui-1.12.1/jquery-ui.min.js?ver=3" type="text/javascript"></script>
 	<script src="../js/symb/collections.harvestparams.js?ver=180721" type="text/javascript"></script>
-	<script src="../js/symb/collections.traitattr.js?ver=8" type="text/javascript"></script> 
+	<script src="../js/symb/collections.cch2traitsearch.js?ver=8" type="text/javascript"></script> <!-- Cotains CCH2 serach-by-trait modifications -->
 	<script type="text/javascript">
 		$(document).ready(function() {
 			<?php
@@ -248,12 +248,14 @@ $searchVar = $collManager->getQueryTermStr();
 				<div><button type="submit" style="width:100%"><?php echo isset($LANG['BUTTON_NEXT_LIST'])?$LANG['BUTTON_NEXT_LIST']:'List Display'; ?></button></div>
 				<div><button type="button" style="width:100%" onclick="displayTableView(this.form)"><?php echo isset($LANG['BUTTON_NEXT_TABLE'])?$LANG['BUTTON_NEXT_TABLE']:'Table Display'; ?></button></div>
 			</div>
-			<div>
-				<div style="font-weight:bold; font-size: 18px"><?php echo $LANG['TRAIT_HEADER']; ?></div>
-			</div>
 			<?php
 				$traitArr = $attribSearch->getTraitArr();
 				if($traitArr){
+					?>
+					<div>
+						<div style="font-weight:bold; font-size: 18px"><?php echo $LANG['TRAIT_HEADER']; ?></div>
+					</div>
+					<?php
 					foreach($traitArr as $traitID => $traitData){
 						if(!isset($traitData['dependentTrait'])) {
 						?>
@@ -274,6 +276,7 @@ $searchVar = $collManager->getQueryTermStr();
 						<?php
 						}
 					}
+					echo '<hr />';
 				}
 			?>
 			<div>

--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -255,7 +255,7 @@ $searchVar = $collManager->getQueryTermStr();
 				<input type='checkbox' name='issterile' value='1' /> <?php echo isset($LANG['IS_STERILE'])?$LANG['IS_STERILE']:'No reproductive structures present (no unopen, open, or senesced flowers or fruits)'; ?>
 			</div>
 			<div>
-				<input type='checkbox' name='isnotscorable' value='1' /> <?php echo isset($LANG['IS_NOTSCORABLE'])?$LANG['IS_NOTSCORABLE']:'Not possible to score reproductive condition using material present'; ?>
+				<input type='checkbox' name='isnotscorable' value='1' /> <?php echo isset($LANG['IS_NOTSCORABLE'])?$LANG['IS_NOTSCORABLE']:'Not possible to score reproductive condition of material'; ?>
 			</div>
 			<div>
 				<input type="hidden" name="reset" value="1" />

--- a/config/symbini_template.php
+++ b/config/symbini_template.php
@@ -61,6 +61,7 @@ $DISPLAY_COMMON_NAMES = 1;			//Display common names in species profile page and 
 $ACTIVATE_EXSICCATI = 0;			//Activates exsiccati fields within data entry pages; adding link to exsiccati search tools to portal menu is recommended
 $ACTIVATE_GEOLOCATE_TOOLKIT = 0;	//Activates GeoLocate Toolkit located within the Processing Toolkit menu items
 $OCCUR_SECURITY_OPTION = 1;			//Occurrence security options supported: value 1-7; 1 = Locality security, 2 = Taxon security, 4 = Full security, 3 = L & T, 5 = L & F, 6 = T & F, 7 = all
+$SEARCH_BY_TRAITS = 0;			//Activates search fields for searching by traits if trait data have been encoded: 0 = trait search off, 1 = trait search on
 
 $IGSN_ACTIVATION = 0;
 

--- a/content/lang/collections/harvestparams.en.php
+++ b/content/lang/collections/harvestparams.en.php
@@ -57,4 +57,5 @@ $LANG['TYPE'] = 'Limit to Type Specimens';
 $LANG['HAS_IMAGE'] = 'Limit to Specimens with Images';
 $LANG['HAS_GENETIC'] = 'Limit to Specimens with Genetic Data';
 $LANG['INCLUDE_CULTIVATED'] = 'Include cultivated/captive occurrences';
+$LANG['TRAIT_HEADER'] = 'Trait Criteria';
 ?>

--- a/content/lang/collections/harvestparams.en.php
+++ b/content/lang/collections/harvestparams.en.php
@@ -58,4 +58,7 @@ $LANG['HAS_IMAGE'] = 'Limit to Specimens with Images';
 $LANG['HAS_GENETIC'] = 'Limit to Specimens with Genetic Data';
 $LANG['INCLUDE_CULTIVATED'] = 'Include cultivated/captive occurrences';
 $LANG['TRAIT_HEADER'] = 'Trait Criteria';
+$LANG['IS_REPRODUCTIVE'] = 'At least one reproductive structure of any kind is present (flowers, flower buds, fruits)';
+$LANG['IS_STERILE'] = 'No reproductive structures present (no unopen, open, or senesced flowers or fruits)';
+$LANG['IS_NOTSCORABLE'] = 'Not possible to score reproductive condition of material';
 ?>

--- a/content/lang/collections/harvestparams.en.php
+++ b/content/lang/collections/harvestparams.en.php
@@ -58,7 +58,4 @@ $LANG['HAS_IMAGE'] = 'Limit to Specimens with Images';
 $LANG['HAS_GENETIC'] = 'Limit to Specimens with Genetic Data';
 $LANG['INCLUDE_CULTIVATED'] = 'Include cultivated/captive occurrences';
 $LANG['TRAIT_HEADER'] = 'Trait Criteria';
-$LANG['IS_REPRODUCTIVE'] = 'At least one reproductive structure of any kind is present (flowers, flower buds, fruits)';
-$LANG['IS_STERILE'] = 'No reproductive structures present (no unopen, open, or senesced flowers or fruits)';
-$LANG['IS_NOTSCORABLE'] = 'Not possible to score reproductive condition of material';
 ?>

--- a/content/lang/collections/harvestparams.es.php
+++ b/content/lang/collections/harvestparams.es.php
@@ -57,4 +57,5 @@ $LANG['TYPE'] = 'Limitar a ejemplares tipo';
 $LANG['HAS_IMAGE'] = 'Limitar a ejemplares con im&aacute;genes';
 $LANG['HAS_GENETIC'] = 'Limitar a ejemplares con datos gen&eacute;ticos';
 $LANG['INCLUDE_CULTIVATED'] = 'Incluye ejemplares cultivadas/cautivas';
+$LANG['TRAIT_HEADER'] = 'Criterios de Rasgos';
 ?>

--- a/content/lang/collections/harvestparams.es.php
+++ b/content/lang/collections/harvestparams.es.php
@@ -58,7 +58,4 @@ $LANG['HAS_IMAGE'] = 'Limitar a ejemplares con im&aacute;genes';
 $LANG['HAS_GENETIC'] = 'Limitar a ejemplares con datos gen&eacute;ticos';
 $LANG['INCLUDE_CULTIVATED'] = 'Incluye ejemplares cultivadas/cautivas';
 $LANG['TRAIT_HEADER'] = 'Criterios de Rasgos';
-$LANG['IS_REPRODUCTIVE'] = 'El esp&eacute;cimen tiene al menos una estructura reproductiva';
-$LANG['IS_STERILE'] = 'El esp&eacute;cimen no tiene estructuras reproductiva';
-$LANG['IS_NOTSCORABLE'] = 'No se puede puntuar la condici&oacute;n reproductiva del esp&eacute;cimen';
 ?>

--- a/content/lang/collections/harvestparams.es.php
+++ b/content/lang/collections/harvestparams.es.php
@@ -58,4 +58,7 @@ $LANG['HAS_IMAGE'] = 'Limitar a ejemplares con im&aacute;genes';
 $LANG['HAS_GENETIC'] = 'Limitar a ejemplares con datos gen&eacute;ticos';
 $LANG['INCLUDE_CULTIVATED'] = 'Incluye ejemplares cultivadas/cautivas';
 $LANG['TRAIT_HEADER'] = 'Criterios de Rasgos';
+$LANG['IS_REPRODUCTIVE'] = 'El esp&eacute;cimen tiene al menos una estructura reproductiva';
+$LANG['IS_STERILE'] = 'El esp&eacute;cimen no tiene estructuras reproductiva';
+$LANG['IS_NOTSCORABLE'] = 'No se puede puntuar la condici&oacute;n reproductiva del esp&eacute;cimen';
 ?>

--- a/js/symb/collections.cch2traitsearch.js
+++ b/js/symb/collections.cch2traitsearch.js
@@ -1,0 +1,53 @@
+// ==== CCH2 Modifications ===============================================
+// The following function enable some of the search-by-trait functionality
+// added for the CCH2 TCN. Code is modified from collections.traitattr.js
+
+$(document).ready(function() {
+	setAttributeTree(null);
+	$(".trianglediv").each(function(){
+		var rootElem = $(this).closest("fieldset");
+		var childClassArr = $(rootElem).find("div[class^=child]");
+		if(childClassArr.length == 0) $(this).hide();
+	});
+});
+
+function traitChanged(elem){
+	var elemType =  elem.getAttribute("type");
+	var elemName = elem.getAttribute("name");
+	var traitID = elemName.substring(8,elemName.length-2);
+	if(elem.checked == true){
+    elem.checked == false;
+	}
+	if(!sessionStorage.attributeTree || sessionStorage.attributeTree == 0){
+		$('input[name="traitid-'+traitID+'[]"]').each(function(){
+			if((elemType == 'text' && elemType.value.trim() != '') || this.checked == true){
+				if(sessionStorage.attributeTree == 0) $("div.child-"+this.value).show();
+			}  // Expands the attribute tree if hidden, but intentionally does not re-hide
+		});
+	}
+}
+
+function setAttributeTree(triggerElem){
+	var toggleTree = false;
+	if(triggerElem) toggleTree = true;
+	var treeOpen = false;
+	if(sessionStorage.attributeTree && sessionStorage.attributeTree == 1) treeOpen = true;
+	if(toggleTree){
+		if(treeOpen) treeOpen = false;
+		else treeOpen = true;
+	}
+	var rootElem = $("#traitdiv");
+	if(triggerElem) rootElem = $(triggerElem).closest("fieldset");
+	if(treeOpen){
+		$(rootElem).find("div[class^=child]").show();
+		$(rootElem).find(".triangledown").show();
+		$(rootElem).find(".triangleright").hide();
+		sessionStorage.attributeTree = 1;
+	}
+	else{
+		$(rootElem).find("div[class^=child]").hide();
+		$(rootElem).find('.triangledown').hide();
+		$(rootElem).find('.triangleright').show();
+		sessionStorage.attributeTree = 0;
+	}
+}

--- a/js/symb/collections.harvestparams.js
+++ b/js/symb/collections.harvestparams.js
@@ -16,7 +16,7 @@ function checkHarvestParamsForm(frm){
 	if((frm.taxa.value.trim() == '') && (frm.country.value.trim() == '') && (frm.state.value.trim() == '') && (frm.county.value.trim() == '') &&
 		(frm.local.value.trim() == '') && (frm.elevlow.value.trim() == '') && (frm.upperlat.value.trim() == '') && (frm.footprintwkt.value.trim() == '') && (frm.pointlat.value.trim() == '') &&
 		(frm.collector.value.trim() == '') && (frm.collnum.value.trim() == '') && (frm.eventdate1.value.trim() == '') && (frm.catnum.value.trim() == '') &&
-		(frm.typestatus.checked == false) && (frm.hasimages.checked == false) && (frm.hasgenetic.checked == false) && (frm.isreproductive.checked == false) && (frm.issterile.checked == false) && (frm.isnotscorable.checked == false)){
+		(frm.typestatus.checked == false) && (frm.hasimages.checked == false) && (frm.hasgenetic.checked == false)){
 		alert("Please fill in at least one search parameter!");
 		return false;
 	}

--- a/js/symb/collections.harvestparams.js
+++ b/js/symb/collections.harvestparams.js
@@ -1,6 +1,6 @@
 function displayTableView(f){
 	f.action = "listtabledisplay.php";
-	f.submit();	
+	f.submit();
 }
 
 function cleanNumericInput(formElem){
@@ -16,7 +16,7 @@ function checkHarvestParamsForm(frm){
 	if((frm.taxa.value.trim() == '') && (frm.country.value.trim() == '') && (frm.state.value.trim() == '') && (frm.county.value.trim() == '') &&
 		(frm.local.value.trim() == '') && (frm.elevlow.value.trim() == '') && (frm.upperlat.value.trim() == '') && (frm.footprintwkt.value.trim() == '') && (frm.pointlat.value.trim() == '') &&
 		(frm.collector.value.trim() == '') && (frm.collnum.value.trim() == '') && (frm.eventdate1.value.trim() == '') && (frm.catnum.value.trim() == '') &&
-		(frm.typestatus.checked == false) && (frm.hasimages.checked == false) && (frm.hasgenetic.checked == false)){
+		(frm.typestatus.checked == false) && (frm.hasimages.checked == false) && (frm.hasgenetic.checked == false) && (frm.isreproductive.checked == false) && (frm.issterile.checked == false) && (frm.isnotscorable.checked == false)){
 		alert("Please fill in at least one search parameter!");
 		return false;
 	}
@@ -70,7 +70,7 @@ function setHarvestParamsForm(){
 	if(sessionStorage.querystr){
 		var urlVar = parseUrlVariables(sessionStorage.querystr);
 		var frm = document.harvestparams;
-		
+
 		if(typeof urlVar.usethes !== 'undefined' && (urlVar.usethes == "" || urlVar.usethes == "0")){frm.usethes.checked = false;}
 		if(urlVar.taxontype){frm.taxontype.value = urlVar.taxontype;}
 		if(urlVar.taxa){frm.taxa.value = urlVar.taxa;}
@@ -113,6 +113,9 @@ function setHarvestParamsForm(){
 		if(typeof urlVar.hasimages !== 'undefined'){frm.hasimages.checked = true;}
 		if(typeof urlVar.hasgenetic !== 'undefined'){frm.hasgenetic.checked = true;}
 		if(typeof urlVar.includecult !== 'undefined'){frm.includecult.checked = true;}
+		if(typeof urlVar.isreproductive !== 'undefined'){frm.isreproductive.checked = true;}
+		if(typeof urlVar.issterile !== 'undefined'){frm.issterile.checked = true;}
+		if(typeof urlVar.isnotscorable !== 'undefined'){frm.isnotscorable.checked = true;}
 		if(urlVar.db){frm.db.value = urlVar.db;}
 	}
 }
@@ -121,7 +124,7 @@ function parseUrlVariables(varStr) {
 	var result = {};
 	varStr.split("&").forEach(function(part) {
 		if(!part) return;
-		part = part.split("+").join(" "); 
+		part = part.split("+").join(" ");
 		var eq = part.indexOf("=");
 		var key = eq>-1 ? part.substr(0,eq) : part;
 		var val = eq>-1 ? decodeURIComponent(part.substr(eq+1)) : "";

--- a/js/symb/collections.harvestparams.js
+++ b/js/symb/collections.harvestparams.js
@@ -113,9 +113,6 @@ function setHarvestParamsForm(){
 		if(typeof urlVar.hasimages !== 'undefined'){frm.hasimages.checked = true;}
 		if(typeof urlVar.hasgenetic !== 'undefined'){frm.hasgenetic.checked = true;}
 		if(typeof urlVar.includecult !== 'undefined'){frm.includecult.checked = true;}
-		if(typeof urlVar.isreproductive !== 'undefined'){frm.isreproductive.checked = true;}
-		if(typeof urlVar.issterile !== 'undefined'){frm.issterile.checked = true;}
-		if(typeof urlVar.isnotscorable !== 'undefined'){frm.isnotscorable.checked = true;}
 		if(urlVar.db){frm.db.value = urlVar.db;}
 	}
 }


### PR DESCRIPTION
Modifications in order to implement a search by traits/attributes. A new configuration flag is added to symbini.php, which is used to trigger emission of the trait attribute options on harvestparams.php. The search works by creating an OccurrenceAttributes instance ($attribSearch) to echo the trait (encoding) form--this is co-opted as a search form--and to add the trait criteria to the SQL search. A new js script file (collections.cch2traitsearch.js) was needed to control the behavior of the attribute tree when users reset or return to the harvestparams.php form.
I have tested this on a local version of the CCH2 portal without any problems noticeable to me, however, I could easily have overlooked something.